### PR TITLE
Add SBE dump HWPs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,7 +102,7 @@ ERROR_PARSER_XML = \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_query_mssinfo_errors.xml \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_ram_errors.xml \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_read_write_iop_xram_errors.xml \
-	$(EKB)/chips/p10/procedures/xml/error_info/p10_sbe_check_quiesce_errors.xml \
+        $(EKB)/chips/p10/procedures/xml/error_info/p10_sbe_check_quiesce_errors.xml \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_sbe_chiplet_pll_initf_errors.xml \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_sbe_chiplet_pll_setup_errors.xml \
 	$(EKB)/chips/p10/procedures/xml/error_info/p10_sbe_common_errors.xml \

--- a/Makefile.istep
+++ b/Makefile.istep
@@ -18,3 +18,9 @@ include ekb/chips/p10/procedures/hwp/perv/p10_pre_poweroff.mk
 include ekb/chips/p10/procedures/hwp/perv/p10_extract_sbe_rc.mk
 include ekb/chips/p10/procedures/hwp/lib/p10_ppe_utils.mk
 include ekb/chips/p10/procedures/hwp/lib/p10_ppe_common.mk
+
+# Procedure required for generating sbe dump.
+include ekb/chips/p10/procedures/hwp/lib/p10_pibmem_dump.mk
+include ekb/chips/p10/procedures/hwp/lib/p10_pibms_reg_dump.mk
+include ekb/chips/p10/procedures/hwp/lib/p10_ppe_state.mk
+include ekb/chips/p10/procedures/hwp/lib/p10_sbe_localreg_dump.mk


### PR DESCRIPTION
- Add support for SBE dump HWPs
- Removed p10_sbe_check_quiesce_errors.xml which is failing to build.