### PR TITLE
libekb: Special error handling for clock errors

### DIFF
--- a/hwpf/fapi2/src/plat/plat_utils.C
+++ b/hwpf/fapi2/src/plat/plat_utils.C
@@ -154,14 +154,8 @@ std::string plat_HwCalloutEnum_tostring(HwCallouts::HwCallout hwcallout)
         case HwCallouts::HwCallout::TOD_CLOCK:
             hwcalloutstr = "TOD_CLOCK";
             break;
-        case HwCallouts::HwCallout::MEM_REF_CLOCK:
-            hwcalloutstr = "MEM_REF_CLOCK";
-            break;
         case HwCallouts::HwCallout::PROC_REF_CLOCK:
             hwcalloutstr = "PROC_REF_CLOCK";
-            break;
-        case HwCallouts::HwCallout::PCI_REF_CLOCK:
-            hwcalloutstr = "PCI_REF_CLOCK";
             break;
         case HwCallouts::HwCallout::FLASH_CONTROLLER_PART:
             hwcalloutstr = "FLASH_CONTROLLER_PART";

--- a/libekb.H
+++ b/libekb.H
@@ -43,6 +43,9 @@ struct HWCallout
     // in POWER cec device tree
     std::vector<uint8_t> target_entity_path;
 
+    // To indicate, a planar callout is required for this error.
+    bool isPlanarCallout;
+
     // To get clock position and it used for identify clock position
     // for processor
     uint8_t clkPos;


### PR DESCRIPTION
-For the clock failure, we have to callout the planar and gard proc
    -Added an extra variable HwCallout structure to indicate planar
     callout is required.
    -Added variable in HWCallout structure to indicate refernce target
     has to be garded

Signed-off-by: Rajees P P <rajerpp1@in.ibm.com>