### PR TITLE
libekb: Removing proc guard on clock failure

### DIFF
--- a/hwpf/fapi2/include/plat/plat_error.H
+++ b/hwpf/fapi2/include/plat/plat_error.H
@@ -13,11 +13,11 @@ namespace fapi2
  * specific to each failures with hwcallout
  *
  * @param[in,out] ffdc ffdc data which need to be updated if it is clock failure
- * @param[in] guardRefTarget indicates whether reference target need to be guarded or not
+ * @param[in] deconfRefTarget indicates whether reference target need to be deconfigured or not
  *
  * @return void
  */
-void process_HW_callout(FFDC &ffdc, const bool guardRefTarget);
+void process_HW_callout(FFDC &ffdc, const bool deconfRefTarget);
 }
 
 #endif

--- a/hwpf/fapi2/src/plat/plat_error.C
+++ b/hwpf/fapi2/src/plat/plat_error.C
@@ -11,20 +11,20 @@ namespace fapi2
  *
  * @param[in,out] ffdc        ffdc data which need to be updated if it is clock failure
  * @param[in,out] hwCallout   reference of hwcallout with clock related hwid
- * @param[in] guardRefTarget  indicates whether reference target need to be guarded or not
+ * @param[in] deconfRefTarget indicates whether reference target need to be deconfigured or not
  *
  * @return void
  */
-static void process_clock_callout(FFDC &ffdc, HWCallout& hwCallout, const bool guardRefTarget)
+static void process_clock_callout(FFDC &ffdc, HWCallout& hwCallout, const bool deconfRefTarget)
 {
 	// Planar callout is required since, clock is not a FRU, its parent has
 	// to be called out, and clock targets parent is Planar.
 	hwCallout.isPlanarCallout = true;
 
 	// This is an override to CDG defined in error xml. We cant add this guard
-	// in xml, since xml is comon for other systems also, where guard is not
+	// in xml, since xml is comon for other systems also, where deconfigured is not
 	// required.
-	if (guardRefTarget)
+	if (deconfRefTarget)
 	{
 		// For clock failures, reference target is always expected in cdg
 		// for callout. If it is not there, which means, this guard is not
@@ -34,22 +34,22 @@ static void process_clock_callout(FFDC &ffdc, HWCallout& hwCallout, const bool g
 			if (cdg.target_entity_path == hwCallout.target_entity_path)
 			{
 				cdg.deconfigure = true;
-				cdg.guard = true;
+				cdg.guard = false;
 				cdg.guard_type = plat_GardTypeEnum_tostring(
-					GardTypes::GardType::GARD_Predictive);
+					GardTypes::GardType::GARD_NULL);
 			}
 		}
 	}
 }
 
-void process_HW_callout(FFDC &ffdc, const bool guardRefTarget)
+void process_HW_callout(FFDC &ffdc, const bool deconfRefTarget)
 {
 	for (auto &hwcallout : ffdc.hwp_errorinfo.hwcallouts)
 	{
 		// only PROC_REF_CLOCK failure is expected in BMC context.
 		if (hwcallout.hwid == "PROC_REF_CLOCK")
 		{
-			process_clock_callout(ffdc, hwcallout, guardRefTarget);
+			process_clock_callout(ffdc, hwcallout, deconfRefTarget);
 		}
 	}
 }

--- a/libekb.C
+++ b/libekb.C
@@ -203,7 +203,7 @@ void libekb_get_ffdc(FFDC& ffdc)
 	fapi2::ReturnCode rc =  fapi2::current_err;
 	libekb_get_ffdc_helper(ffdc, rc);
 	// For clock hwp error happened inside BMC context, the proc
-	// target has to be guarded
+	// target has to be deconfigured
 	fapi2::process_HW_callout(ffdc, true);
 }
 
@@ -261,6 +261,6 @@ void libekb_get_sbe_ffdc(FFDC& ffdc, const sbeFfdcPacketType& ffdc_pkt, int proc
 	//update ffdc structre based on new RC
 	libekb_get_ffdc_helper(ffdc, rc);
 	// For clock hwp error happened inside SBE context, the proc
-	// target should not to be guarded
+	// target should not to be deconfigured
 	fapi2::process_HW_callout(ffdc, false);
 }


### PR DESCRIPTION
- For the clock failure at istep 0.7, current bmc code will callout the
  the planar and guard and deconfigure the proc. This will mandate PE's
  to manually remove the guard after replacing the planar.
- Fixing this issue by removeing the guard. So, proc will be only
  deconfigured on clock failure.
- This has a side effect, that same clock error will be reported at istep
  8.3 also.
Tested:
Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x3000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Power Control Net Fault":  "False",
    "Backplane CCIN":           "2E42",
    "Terminate FW Error":       "False",
    "Deconfigured":             "True",
    "Guarded":                  "False",

    "LOG007 2022-03-16 04:39:43": "err: p10_clock_test_latches:163 p10_clock_test_check_error(i_target_chip, i_cp_refclock_select, set_rcs_clock_test_in, l_data32) failed.\n",
    "LOG008 2022-03-16 04:39:43": "err: p10_clock_test_loop:129 p10_clock_test_latches(i_target_chip, i_cp_refclock_select, true) failed.\n",
    "LOG009 2022-03-16 04:39:43": "err: p10_clock_test:102 p10_clock_test_loop(i_target_chip, l_cp_refclck_select) failed.\n",
    "LOG010 2022-03-16 04:39:43": "HWP clock_test failed on proc 1, rc=2129758868\n",
    "_PID": "4605"
},
"User Data 2": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "Data": [
        {
            "Deconfigured": false,
            "Guarded": false,
            "InventoryPath": "/xyz/openbmc_project/inventory/system/chassis/motherboard",
            "Priority": "H"

Signed-off-by: Rajees P P <rajerpp1@in.ibm.com>