### PR TITLE
Adding PCI_REF_CLOCK callout

### DIFF
--- a/hwpf/fapi2/src/plat/plat_error.C
+++ b/hwpf/fapi2/src/plat/plat_error.C
@@ -46,8 +46,9 @@ void process_HW_callout(FFDC &ffdc, const bool deconfRefTarget)
 {
 	for (auto &hwcallout : ffdc.hwp_errorinfo.hwcallouts)
 	{
-		// only PROC_REF_CLOCK failure is expected in BMC context.
-		if (hwcallout.hwid == "PROC_REF_CLOCK")
+		// only PROC_REF_CLOCK & PCI_REF_CLOCK failure is expected in BMC context.
+		if ((hwcallout.hwid == "PROC_REF_CLOCK") ||
+			(hwcallout.hwid == "PCI_REF_CLOCK"))
 		{
 			process_clock_callout(ffdc, hwcallout, deconfRefTarget);
 		}

--- a/hwpf/fapi2/src/plat/plat_utils.C
+++ b/hwpf/fapi2/src/plat/plat_utils.C
@@ -154,6 +154,9 @@ std::string plat_HwCalloutEnum_tostring(HwCallouts::HwCallout hwcallout)
         case HwCallouts::HwCallout::PROC_REF_CLOCK:
             hwcalloutstr = "PROC_REF_CLOCK";
             break;
+        case HwCallouts::HwCallout::PCI_REF_CLOCK:
+            hwcalloutstr = "PCI_REF_CLOCK";
+            break;
         default:
             FAPI_ERR("Unsupported HwCalloutEnum[%d] for tostring\n", hwcallout);
             break;


### PR DESCRIPTION
- This hwid will be used to callout when there is a PCI clock
  related failure.
- Need to callout the PLANAR for this hwid.
Tested:
"User Data 5": {
    "Section Version": "1",
    "Sub-section type": "3",
    "Created by": "0x2000",
    "Data": [
        "HWP_RC = RC_P10_PCI_REFCLOCK_ERR",
        "HWP_RC_DESC = First SCOM attempted into PCI chiplet failed",
        "HWP_FFDC_TARGET = 6b3a7570 306e3a30 3a30733a 00303070 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000",
        "HWP_FFDC_CHIPLET_NUM = 05",
        "HWP_FFDC_CLOCK_MUX = 56",
        "HWP_HW_CO_01_HW_ID = PCI_REF_CLOCK",
        "HWP_HW_CO_01_PRIORITY = HIGH",
        "HWP_HW_CO_01_LOC_CODE = Ufcs-P0-C15",
        "HWP_HW_CO_01_PHYS_PATH = physical:sys-0/node-0/proc-0",
        "HWP_HW_CO_01_CLK_POS = 255",
        "HWP_HW_CO_01_CALLOUT_PLANAR = true",
        "HWP_CDG_TGT_01_LOC_CODE = Ufcs-P0-C15",
        "HWP_CDG_TGT_01_PHYS_PATH = physical:sys-0/node-0/proc-0",
        "HWP_CDG_TGT_01_CO_REQ = true",
        "HWP_CDG_TGT_01_CO_PRIORITY = HIGH",
        "HWP_CDG_TGT_01_DECONF_REQ = false",
        "HWP_CDG_TGT_01_GUARD_REQ = false",
        "HWP_CDG_TGT_01_GUARD_TYPE = GARD_Fatal",
        "."
    ]
}

Signed-off-by: Rajees P P <rajerpp1@in.ibm.com>