### PR TITLE
tools: enable hex format display support in scom ffdc userdata

### DIFF
--- a/hwpf/fapi2/tools/platCreateHwpErrParser.pl
+++ b/hwpf/fapi2/tools/platCreateHwpErrParser.pl
@@ -160,6 +160,8 @@ print TGFILE "#ifndef PLATHWPERRPARSERFFDC_H_\n";
 print TGFILE "#define PLATHWPERRPARSERFFDC_H_\n\n";
 print TGFILE "#include <netinet/in.h>\n\n";
 print TGFILE "#include <iomanip>\n";
+print TGFILE "#include <sstream>\n";
+
 print TGFILE "#include \"hwp_pel_data.H\"\n\n";
 print TGFILE "namespace fapi2\n";
 print TGFILE "{\n\n";
@@ -207,7 +209,9 @@ foreach my $argnum (0 .. $#ARGV)
             print TGFILE "        case 0x$ffdcHash32Bit:\n";
             print TGFILE "            {uint64_t address =\n";
             print TGFILE "            be64toh(*(reinterpret_cast<const uint64_t*>(buf)));\n";
-            print TGFILE "            pelData.append(\"Failed SCOM address\", address);}\n";
+            print TGFILE "            std::stringstream ss;\n";
+            print TGFILE "            ss << \"0x\" << std::hex << address;\n";
+            print TGFILE "            pelData.append(\"Failed SCOM address\", ss.str());}\n";
             print TGFILE "            break;\n";
 
             $ffdcName = $err->{rc} . "_pcb_pib_rc";
@@ -216,7 +220,9 @@ foreach my $argnum (0 .. $#ARGV)
 
             print TGFILE "        case 0x$ffdcHash32Bit:\n";
             print TGFILE "            {uint32_t pibRc = be32toh(*(reinterpret_cast<const uint32_t *>(buf)));\n";
-            print TGFILE "            pelData.append(\"PIB RC\", pibRc);}\n";
+            print TGFILE "            std::stringstream ss;\n";
+            print TGFILE "            ss << \"0x\" << std::hex << pibRc;\n";
+            print TGFILE "            pelData.append(\"PIB RC\", ss.str());}\n";
             print TGFILE "            break;\n";
         }
         foreach my $ffdc (@{$err->{ffdc}})


### PR DESCRIPTION
Added support to change the scom failure ffdc user data
into hex format.

