### PR TITLE
libekb - Disable compiler flag for stack protection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,11 +200,12 @@ include Makefile.proc.am
 OPTFLAGS = -Os -O2
 LOCALCFLAGS = $(OPTFLAGS) -g -Wall -std=gnu11 $(TARGET_ENDIAN)
 
+# TODO #libekb_p10/issues/15 remove -fno-stack-protector
 # Our own platform include files (hwpf/fapi2/include/plat) shoud
 # appear before the ekb ones in this list as we need the compiler to
 # choose some of ours. Specifically return_code_defs.H.
 LOCALCXXFLAGS = $(OPTFLAGS) -Wall -std=gnu++11 \
-		-fpermissive -fno-exceptions -fno-rtti \
+		-fpermissive -fno-exceptions -fno-stack-protector -fno-rtti \
 		$(TARGET_ENDIAN) \
 		-I$(ATTRIB_DIR) \
 		-I$(ERROR_INFO_DIR) \


### PR DESCRIPTION
libekb is built with -fstack-protector-strong and it is causing
stack smashing issues during execution of HWP.

Older builds and systems were not using this flag so we never
hit stack smashing issue and application crash.

what is -fstack-protector
Emit extra code to check for buffer overflows, such as stack
smashing attacks. This is done by adding a guard variable to
functions with vulnerable objects. This includes functions
that call alloca, and functions with buffers larger than
8 bytes. The guards are initialized when a function is
entered and then checked when the function exits. If a guard
check fails, an error message is printed and the program exits.

At present there are lot of compiler warnings related to size
and buffer allocation during ekb hardware procedure build.
Until the HWP compiler warnings are fixed and code is reevaluated
for buffer overflows by enabling the stack-protection flag
we might hit error.

Tested:
Tested multiple times to see stack smashing does not happen
during p10_extract_sbe_rc and also ensured that SBE and hardware
dumps are collected succesfully.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Idfea72766a3a2e5cfbc78af401fc9f4ccafde24e