### PR TITLE
fapi2: Use %p to print target pointer

### DIFF
--- a/hwpf/fapi2/include/plat/target.H
+++ b/hwpf/fapi2/include/plat/target.H
@@ -446,7 +446,7 @@ inline void toString(const Target<T, M, V> &i_target, char *i_buffer,
 	if (!pdbg_target_get_attribute(target, "ATTR_FAPI_NAME", 1,
 				       fapiname_size, fapiname)) {
 		FAPI_ERR("Could not read ATTR_FAPI_NAME attribute");
-		snprintf(i_buffer, i_bsize, "Target 0x%lX/0x%.16lX/0x%X",
+		snprintf(i_buffer, i_bsize, "Target %p/0x%.16lX/0x%X",
 			 i_target.get(), T, M);
 	} else {
 		if (i_bsize < fapiname_size) {


### PR DESCRIPTION
GCC 13 warns about a the wrong format specifier when building for some platforms:

 ./hwpf/fapi2/include/plat/target.H:449:57: warning: format '%lX' expects
 argument of type 'long unsigned int', but argument 4 has type
 'pdbg_target*' [-Wformat=]

Use %p to print a pointer value, as this will work on arm/x86/ppc64 no matter the size of a pointer.

Fixes https://github.com/open-power/pub-ekb/issues/2