### PR TITLE
Add needed cstdint include

### DIFF
--- a/libekb.H
+++ b/libekb.H
@@ -14,6 +14,7 @@
 
 extern "C" {
 #include <stdarg.h>
+#include <cstdint>
 
 typedef void (*libekb_log_func_t)(void *private_data, const char *fmt,
 				  va_list ap);


### PR DESCRIPTION
Without this, gcc-13 is logging the following error:

```
| ../git/libekb.H:17:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
|    16 | #include <stdarg.h>
|   +++ |+#include <cstdint>
```