### PR TITLE
EKB bump and sbeAttrSync fix

### DIFF
--- a/scripts/attribute.py
+++ b/scripts/attribute.py
@@ -6,7 +6,8 @@ import xml.etree.ElementTree as ET
 ignore_tags = ['description', 'platInit', 'writeable', 'overrideOnly',
                'persistRuntime', 'mssUnit', 'mssUnits', 'mssAccessorName',
                'odmVisable', 'odmChangeable', 'mssBlobStart', 'mssBlobLength',
-               'privileged', 'platActionWrite', 'mrwHide', 'group', 'mrw' ]
+               'privileged', 'platActionWrite', 'mrwHide', 'group', 'mrw',
+               'sbeAttrSync']
 
 data_types = ['uint8', 'uint16', 'uint32', 'uint64',
               'int8', 'int16', 'int32', 'int64']


### PR DESCRIPTION
When updating the EKB there is a build error due to a new tag being added. Add it to the ignore list.