### PR TITLE
Add new api to parse sbe ffdc data for p12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,18 @@ AC_ARG_ENABLE([db-install],
 		       [Enable installation of attribute database]))
 AM_CONDITIONAL([BUILD_DB], [test "x$enable_db_install" = "xyes"])
 
+AC_LANG([C++])
+# Adding the required C++ version directly is not typically recommended
+# practice. However, Autotools does not support AX_CXX_COMPILE_STDCXX_23 or
+# AX_CXX_COMPILE_STDCXX for version 23.
+saved_CXXFLAGS=$CXXFLAGS
+CXXFLAGS="$saved_CXXFLAGS -std=c++23"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <expected>],
+                                   [std::expected<int, int> testObj;])],
+                  [saved_CXXFLAGS="$saved_CXXFLAGS -std=c++23"],
+                  [AC_MSG_ERROR([C++23 is not supported, but it is required])])
+CXXFLAGS=$saved_CXXFLAGS
+
 AC_PROG_CC
 AC_PROG_CXX
 AM_PROG_AS

--- a/libekb.C
+++ b/libekb.C
@@ -19,6 +19,8 @@ extern "C" {
 #include <set_sbe_error.H>
 
 #include <vector>
+#include <cstring>
+#include <iostream>
 
 static libekb_log_func_t __libekb_log_fn;
 static void* __libekb_log_priv;
@@ -174,7 +176,6 @@ void libekb_get_ffdc_helper(FFDC& ffdc, fapi2::ReturnCode& rc)
 		    "No FFDC, libekb_get_ffdc() called for success case";
 		return;
 	}
-
 	if (rc.getCreator() == fapi2::ReturnCode::CREATOR_HWP) {
 		ffdc.ffdc_type = FFDC_TYPE_HWP;
 		get_HWPErrorInfo(rc, ffdc.hwp_errorinfo);
@@ -265,4 +266,49 @@ void libekb_get_sbe_ffdc(FFDC& ffdc, const sbeFfdcPacketType& ffdc_pkt,
 	// For clock hwp error happened inside SBE context, the proc
 	// target should not to be deconfigured
 	fapi2::process_HW_callout(ffdc, false);
+}
+
+void libekb_parse_sbe_ffdc_pkt(uint32_t fapiRc,
+			const std::vector<uint8_t>& blobData,
+			int chipPos, uint32_t sbeChipType, FFDC&ffdc)
+{
+	using namespace fapi2;
+	libekb_log(LIBEKB_LOG_INF,
+		"chip pos: %d  chip type 0x%08X  fapirc: 0x%x length: %zu\n",
+		chipPos, sbeChipType, fapiRc, blobData.size());
+
+	constexpr size_t sbeFfdcSize = sizeof(sbeFfdc_t);
+	std::vector<sbeFfdc_t> ffdc_endian;
+	const sbeFfdc_t* sbe_ffdc = reinterpret_cast<const sbeFfdc_t*>(blobData.data());
+	size_t size = blobData.size();
+	// Parse and convert all entries
+	for (size_t i = 0; i < size; i += sbeFfdcSize, sbe_ffdc++)
+	{
+		sbeFfdc_t ffdc_data;
+		ffdc_data.size = ntohl(sbe_ffdc->size);
+		// Special type FFDC size need endianess conversion in data.
+		// TODO: Endianess for size "1, 2, 4" need to revisit.
+		if ((ffdc_data.size == EI_FFDC_SIZE_TARGET) ||
+			(ffdc_data.size == EI_FFDC_SIZE_BUF) ||
+			(ffdc_data.size == EI_FFDC_SIZE_VBUF) ||
+			(ffdc_data.size == EI_FFDC_MAX_SIZE)) {
+				ffdc_data.data = be64toh(sbe_ffdc->data);
+		} else {
+			ffdc_data.data = sbe_ffdc->data;
+		}
+		ffdc_endian.push_back(ffdc_data);
+	}
+	// Convert to FAPI RC
+	fapi2::ReturnCode rc;
+	if(ffdc_endian.size() > 0)
+	{
+		FAPI_SET_SBE_ERROR(rc, fapiRc, ffdc_endian.data(), chipPos,
+			static_cast<fapi2::TargetType>(sbeChipType));
+
+		libekb_log(LIBEKB_LOG_INF, " New FAPI RC: 0x%x\n", rc);
+
+		// Fill FFDC struct
+		libekb_get_ffdc_helper(ffdc, rc);
+		fapi2::process_HW_callout(ffdc, false);
+    }
 }

--- a/libekb.H
+++ b/libekb.H
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cstddef>
 
 #define LIBEKB_LOG_ERR 0
 #define LIBEKB_LOG_INF 1
@@ -201,4 +202,8 @@ void libekb_get_ffdc(FFDC &ffdc);
  */
 void libekb_get_sbe_ffdc(FFDC &ffdc, const sbeFfdcPacketType &ffdc_pkt,
 			 int chipPos, uint32_t sbeChipType);
+
+void libekb_parse_sbe_ffdc_pkt(uint32_t fapiRc,
+                  const std::vector<uint8_t>& blobData,
+                  int chipPos, uint32_t sbeChipType, FFDC&ffdc);
 #endif /* __LIBEKB_H__ */


### PR DESCRIPTION
Tested:
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "bmc error logging",
    "HWP_FFDC_INVALID_ERRVAL": "000c0af0",
    "HWP_FFDC_Unrecognized FFDC": "fbad0039 01a80000 00000400 000c0af0 00000000 4910957a ff000000 04000000 38100400 00020000 5f454253 43415254 45000000 00000000 0f300000 38131000 af2923fe 0046c323 00000000 ffffffff 8ffa73ef 00000018 d85f0100 00000000 00000000 01018d2c 063e5c9d 5fd60000 11435c9d 060039a6 9f4d53a9 7ada0000 00000000 d0a40102 1e564d9f 00000000 00000001 02019cc4 da584d9f 91a00006 f15a4d9f 000020c9 9f4d6021 01000000 00000000 eb800102 c6614d9f a2000000 00000001 0201771f 36c1629f 000000a2 01000000 0201f1f0 9f62c392 03000000 addeadde 01017fec 62e6b3af 0000d65f",
    "HWP_RC": "RC_ERROR_UNSUPPORTED_BY_SBE",
    "HWP_RC_DESC": "An error was encountered that the SBE didn't expect.",
    "SRC6": "0"
},
Change-Id: I13595e03d33c865cc6a9515e3081ae5caf9a38bd